### PR TITLE
Reintegrate elm bridge

### DIFF
--- a/dbc2val/Readme.md
+++ b/dbc2val/Readme.md
@@ -303,7 +303,7 @@ Available loggers:
 
 The feeder works best with a real CAN interface. If you use an OBD Dongle the feeder can configure it to use it as a CAN Sniffer
 (using  `STM` or `STMA` mode). The elmbridge will talk to the OBD Adapter using its custom AT protocol, parse the received CAN frames,
-and put them into a virtual CAN device. The DBC feeder can not tell the differenc
+and put them into a virtual CAN device. The DBC feeder can not tell the difference.
 
 There are some limitations in this mode
  * Does not support generic ELM327 adapters but needs to have the ST commands from the OBDLink Devices available:
@@ -311,14 +311,14 @@ There are some limitations in this mode
  * Bandwidth/buffer overrun on Raspberry Pi internal UARTs:When connecting the STN to one of the Pis internal UARTs you will
  loose messages on fully loaded CAN busses (500kbit does not work when it is very loaded). The problem is not the raw bandwith
  (The Pi `/dev/ttyAMA0` UART can go up to 4 MBit when configured accordingly), but rather that the Pi UART IP block does not support
- DMA and has only an 8 bytes buffer. If the system is loaded, and you get scheduled a little too late, the overrun already occuured.
+ DMA and has only an 8 bytes buffer. If the system is loaded, and you get scheduled a little too late, the overrun already occurred.
  While this makes this setup a little useless for a generic sniffer, in most use cases it is fine, as the code configures a dynamic
- whitelist according to the confgured signals, i.e. the STN is instructed to only let CAN messages containing signals of interest pass.
+ whitelist according to the configured signals, i.e. the STN is instructed to only let CAN messages containing signals of interest pass.
 
 When using the OBD chipset, take special attention to the `obdcanack` configuration option: On a CAN bus there needs to be _some_ device
 to acknowledge CAN frames. The STN2120 can do this. However, when tapping a vehicle bus, you probbably do not want it (as there are otehr
 ECUs on the bus doing it, and we want to be as passive as possible). On theother hand, on a desk setup where you have one CAN sender and
-the OBD chipst, you need to enable Acks, otherwise the CAN sender will go into error mode, if no acknowledgement is received.
+the OBD chipset, you need to enable Acks, otherwise the CAN sender will go into error mode, if no acknowledgement is received.
 
 ## SAE-J1939 support
 

--- a/dbc2val/createvcan.sh
+++ b/dbc2val/createvcan.sh
@@ -31,15 +31,15 @@ then
     DEV=$1
 fi
 
-echo "Preparing to bring up vcan interface $DEV"
+echo "createvcan: Preparing to bring up vcan interface $DEV"
 
 virtualCanConfigure() {
-	echo "Setting up VIRTUAL CAN"
+	echo "createvcan: Setting up VIRTUAL CAN"
 	sudo  modprobe -n --first-time vcan &> /dev/null
 	loadmod=$?
 	if [ $loadmod -eq 0 ]
 	then
-		echo "Virtual CAN module not yet loaded. Loading......"
+		echo "createvcan: Virtual CAN module not yet loaded. Loading......"
 		sudo modprobe vcan
 	fi
 
@@ -48,7 +48,7 @@ virtualCanConfigure() {
 	noif=$?
 	if [ $noif -eq 1 ]
 	then
-		echo "Virtual CAN interface not yet existing. Creating..."
+		echo "createvcan: Virtual CAN interface not yet existing. Creating..."
 		sudo ip link add dev "$DEV" type vcan
 	fi
 	sudo ip link set "$DEV" up
@@ -61,12 +61,12 @@ up=$(ifconfig "$DEV" 2> /dev/null | grep NOARP | grep -c RUNNING)
 
 if [ $up -eq 1 ]
 then
-   echo "Interface already up. Exiting"
+   echo "createvcan: Interface already up. Exiting"
    exit
 fi
 
 virtualCanConfigure
 
-echo "Done."
+echo "createvcan: Done."
 
 

--- a/dbc2val/dbcfeeder.py
+++ b/dbc2val/dbcfeeder.py
@@ -37,6 +37,7 @@ import dbc2vssmapper
 import dbcreader
 import grpc
 import j1939reader
+import elm2canbridge
 
 from kuksa_client import KuksaClientThread
 import kuksa_client.grpc
@@ -94,7 +95,8 @@ class ColorFormatter(logging.Formatter):
 
 
 class Feeder:
-    def __init__(self, server_type: ServerType, kuksa_client_config: Dict[str, Any]):
+    def __init__(self, server_type: ServerType, kuksa_client_config: Dict[str, Any],
+                 elmcan_config: Dict[str, Any]):
         self._shutdown = False
         self._reader = None
         self._player = None
@@ -105,6 +107,7 @@ class Feeder:
         self._can_queue = queue.Queue()
         self._server_type = server_type
         self._kuksa_client_config = kuksa_client_config
+        self._elmcan_config = elmcan_config
         self._exit_stack = contextlib.ExitStack()
 
     def start(
@@ -144,6 +147,12 @@ class Feeder:
             )
             self._player.start_replaying(canport=canport)
         else:
+
+            if canport == 'elmcan':
+
+                log.info("Using elmcan. Trying to set up elm2can bridge")
+                elmbr = elm2canbridge.elm2canbridge(canport, self._elmcan_config, self._reader.canidwl)
+
             # use socketCAN
             log.info("Using socket CAN device '%s'", canport)
             self._reader.start_listening(bustype="socketcan", channel=canport)
@@ -429,7 +438,17 @@ def main(argv):
     else:
         grpc_metadata = None
 
-    feeder = Feeder(server_type, kuksa_client_config)
+    elmcan_config = []
+    if canport == "elmcan":
+        if candumpfile != None:
+            log.error("It is a contradiction specifying both elmcan and candumpfile!")
+            sys.exit(-1)
+        if not "elmcan" in config:
+            log.error("Cannot use elmcan without elmcan config!")
+            sys.exit(-1)
+        elmcan_config = config["elmcan"]
+
+    feeder = Feeder(server_type, kuksa_client_config, elmcan_config)
 
     def signal_handler(signal_received, frame):
         log.info(f"Received signal {signal_received}, stopping...")

--- a/dbc2val/elm2canbridge.py
+++ b/dbc2val/elm2canbridge.py
@@ -35,7 +35,10 @@ class elm2canbridge:
     def __init__(self, canport, cfg, whitelist=None):
         print("Try setting up elm2can bridge")
         print("Creating virtual CAN interface")
-        os.system("./createelmcanvcan.sh")
+        result = os.system("./createvcan.sh")
+        if (not os.WIFEXITED(result)) or os.WEXITSTATUS(result) != 0:
+            print(f"Calling createvcan.sh failed with error code {os.WEXITSTATUS(result)}")
+            sys.exit(-1)
 
         self.canport = canport
         self.whitelist=whitelist
@@ -43,7 +46,11 @@ class elm2canbridge:
         elm.baudrate = cfg['baud']
         elm.port = cfg['port']
         elm.timeout = 10
-        elm.open()
+        try:
+            elm.open()
+        except Exception as e:
+            print(f"Could not open elm port, exception {e}")
+            sys.exit(-1)
 
         if not elm.is_open:
             print("elm2canbridge: Can not open serial port")


### PR DESCRIPTION
This is a low effort to re-integrate the elm code. It has not been tested. This is how far it comes as of today:

```
2023-01-30 16:19:43,113 INFO dbcfeeder: Using elmcan. Trying to set up elm2can bridge
Try setting up elm2can bridge
Creating virtual CAN interface
createvcan: Preparing to bring up vcan interface elmcan
createvcan: Setting up VIRTUAL CAN
Cannot find device "elmcan"
createvcan: Done.
Could not open elm port, exception [Errno 2] could not open port /dev/ttyAMA0: [Errno 2] No such file or directory: '/dev/ttyAMA0'
```
